### PR TITLE
feat: 커뮤니티 유저 정보 API 추가

### DIFF
--- a/src/main/java/porori/backend/user/domain/user/application/dto/req/UserRequestDto.java
+++ b/src/main/java/porori/backend/user/domain/user/application/dto/req/UserRequestDto.java
@@ -10,6 +10,8 @@ import porori.backend.user.domain.user.domain.entity.UserConstant;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import java.util.LinkedList;
+import java.util.List;
 
 public class UserRequestDto {
     @Getter
@@ -107,5 +109,13 @@ public class UserRequestDto {
 
         private String accessToken;
 
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    @NoArgsConstructor
+    public static class GetCommunityUserInfoRequest{
+        private List<Long> userIdList;
     }
 }

--- a/src/main/java/porori/backend/user/domain/user/application/dto/res/UserResponseDto.java
+++ b/src/main/java/porori/backend/user/domain/user/application/dto/res/UserResponseDto.java
@@ -1,5 +1,6 @@
 package porori.backend.user.domain.user.application.dto.res;
 
+import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.annotations.ApiModel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -7,6 +8,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import porori.backend.user.domain.user.domain.entity.User;
 import porori.backend.user.global.dto.TokenInfoResponse;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class UserResponseDto {
 
@@ -63,4 +67,31 @@ public class UserResponseDto {
                     .build();
         }
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @ApiModel(description = "사용자 정보 객체")
+    public static class GetCommunityUserInfoResponse {
+        private List<CommunityUserInfoBlocks> communityUserInfoBlocks = new ArrayList<>();
+    }
+
+    @Getter
+    public static class CommunityUserInfoBlocks {
+        private Long userId;
+        private String image;
+        private String backgroundColor;
+        private String nickname;
+
+        @QueryProjection
+        public CommunityUserInfoBlocks(Long userId, String image, String backgroundColor, String nickname) {
+            this.userId = userId;
+            this.image = image;
+            this.backgroundColor = backgroundColor;
+            this.nickname = nickname;
+        }
+    }
+
+
 }

--- a/src/main/java/porori/backend/user/domain/user/application/service/UserInfoService.java
+++ b/src/main/java/porori/backend/user/domain/user/application/service/UserInfoService.java
@@ -5,7 +5,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import porori.backend.user.domain.user.application.dto.req.UserRequestDto;
 import porori.backend.user.domain.user.application.dto.res.UserResponseDto;
+import porori.backend.user.domain.user.application.dto.res.UserResponseDto.GetCommunityUserInfoResponse;
 import porori.backend.user.domain.user.domain.entity.User;
+import porori.backend.user.domain.user.domain.service.UserQueryService;
 import porori.backend.user.domain.user.domain.service.UserValidationService;
 import porori.backend.user.global.config.security.jwt.TokenProvider;
 
@@ -17,11 +19,16 @@ import javax.transaction.Transactional;
 public class UserInfoService {
     private final TokenProvider tokenProvider;
     private final UserValidationService userValidationService;
+    private final UserQueryService userQueryService;
 
-    public UserResponseDto.GetUserInfoResponse getUserInfo(UserRequestDto.GetUserInfoRequest getUserInfoRequest){
+    public UserResponseDto.GetUserInfoResponse getUserInfo(UserRequestDto.GetUserInfoRequest getUserInfoRequest) {
         Authentication authentication = tokenProvider.getAuthentication(getUserInfoRequest.getAccessToken());
         User user = userValidationService.validateAppleId(authentication.getName());
         return UserResponseDto.GetUserInfoResponse.from(user);
+    }
+
+    public GetCommunityUserInfoResponse getCommunityUserInfo(UserRequestDto.GetCommunityUserInfoRequest getCommunityUserInfoRequest) {
+        return userQueryService.getCommunityUserInfoByUserIdList(getCommunityUserInfoRequest);
     }
 
 }

--- a/src/main/java/porori/backend/user/domain/user/domain/repository/UserRepositoryCustom.java
+++ b/src/main/java/porori/backend/user/domain/user/domain/repository/UserRepositoryCustom.java
@@ -1,11 +1,13 @@
 package porori.backend.user.domain.user.domain.repository;
 
+import porori.backend.user.domain.user.application.dto.res.UserResponseDto.GetCommunityUserInfoResponse;
 import porori.backend.user.domain.user.domain.entity.User;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepositoryCustom {
-
     Optional<User> findNotWithdrawByAppleId(String appleId);
 
+    GetCommunityUserInfoResponse findCommunityUserInfoByUserIdList(List<Long> userIdList);
 }

--- a/src/main/java/porori/backend/user/domain/user/domain/repository/UserRepositoryCustomImpl.java
+++ b/src/main/java/porori/backend/user/domain/user/domain/repository/UserRepositoryCustomImpl.java
@@ -1,10 +1,12 @@
 package porori.backend.user.domain.user.domain.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import porori.backend.user.domain.user.domain.entity.QUser;
+import porori.backend.user.domain.user.application.dto.res.QUserResponseDto_CommunityUserInfoBlocks;
+import porori.backend.user.domain.user.application.dto.res.UserResponseDto;
 import porori.backend.user.domain.user.domain.entity.User;
 
 import javax.persistence.EntityManager;
+import java.util.List;
 import java.util.Optional;
 
 import static porori.backend.user.domain.user.domain.entity.QUser.user;
@@ -25,5 +27,18 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
                 .where(user.appleId.eq(appleId),
                         user.withdrawalStatus.eq(false))
                 .fetchFirst());
+    }
+
+    @Override
+    public UserResponseDto.GetCommunityUserInfoResponse findCommunityUserInfoByUserIdList(List<Long> userIdList) {
+        List<UserResponseDto.CommunityUserInfoBlocks> blocks = queryFactory.select(new QUserResponseDto_CommunityUserInfoBlocks(
+                        user.userId,
+                        user.imageUrl,
+                        user.backgroundColor,
+                        user.nickName))
+                .from(user)
+                .where(user.userId.in(userIdList)) // userIdList 내의 userId들을 기준으로 조회
+                .fetch();
+        return new UserResponseDto.GetCommunityUserInfoResponse(blocks);
     }
 }

--- a/src/main/java/porori/backend/user/domain/user/domain/service/UserQueryService.java
+++ b/src/main/java/porori/backend/user/domain/user/domain/service/UserQueryService.java
@@ -1,0 +1,21 @@
+package porori.backend.user.domain.user.domain.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import porori.backend.user.domain.user.application.dto.req.UserRequestDto;
+import porori.backend.user.domain.user.application.dto.res.UserResponseDto;
+import porori.backend.user.domain.user.domain.repository.UserRepository;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserQueryService {
+    private final UserRepository userRepository;
+
+    public UserResponseDto.GetCommunityUserInfoResponse getCommunityUserInfoByUserIdList(UserRequestDto.GetCommunityUserInfoRequest getCommunityUserInfoRequest){
+       return userRepository.findCommunityUserInfoByUserIdList(getCommunityUserInfoRequest.getUserIdList());
+    }
+}

--- a/src/main/java/porori/backend/user/domain/user/presentation/UserController.java
+++ b/src/main/java/porori/backend/user/domain/user/presentation/UserController.java
@@ -39,7 +39,7 @@ public class UserController {
     }
 
     @ApiOperation(value = "추가 정보 입력", notes = "추가 정보를 입력합니다.")
-    @PostMapping("/additional-info")
+    @PutMapping("/additional-info")
     public ResponseEntity<ResponseDto<LoginResponse>> additionalInfo(@Valid @RequestBody AdditionInfoRequest additionInfoRequest) {
         return ResponseEntity.ok(ResponseDto.create(HttpStatus.OK.value(), SIGN_UP_SUCCESS.getMessage(), this.userSignUpService.signup(additionInfoRequest)));
     }
@@ -75,6 +75,12 @@ public class UserController {
     @PostMapping("/test/jwt")
     public ResponseEntity<ResponseDto<LoginResponse>> jwtTokenTest() {
         return ResponseEntity.ok(ResponseDto.create(HttpStatus.OK.value(), VALID_TOKEN.getMessage()));
+    }
+
+    @ApiOperation(value="커뮤니티 회원 정보 보기" , notes="커뮤니티 회원 정보 보기")
+    @PostMapping("/communities/info")
+    public ResponseEntity<ResponseDto<UserResponseDto.GetCommunityUserInfoResponse>> getCommunityUserInfo(@Valid @RequestBody GetCommunityUserInfoRequest getCommunityUserInfoRequest){
+        return ResponseEntity.ok(ResponseDto.create(HttpStatus.OK.value(), GET_COMMUNITY_USERINFO_SUCCESS.getMessage(), this.userInfoService.getCommunityUserInfo(getCommunityUserInfoRequest)));
     }
 }
 

--- a/src/main/java/porori/backend/user/domain/user/presentation/constant/EUserResponseMessage.java
+++ b/src/main/java/porori/backend/user/domain/user/presentation/constant/EUserResponseMessage.java
@@ -11,7 +11,8 @@ public enum EUserResponseMessage {
     DELETE_SUCCESS("회원 탈퇴를 하였습니다"),
     LOGOUT_SUCCESS("로그아웃을 하였습니다"),
     VALID_TOKEN("유효한 토큰입니다"),
-    GET_USERINFO_SUCCESS("사용자 정보 조회를 완료했습니다");
+    GET_USERINFO_SUCCESS("사용자 정보 조회를 완료했습니다"),
+    GET_COMMUNITY_USERINFO_SUCCESS("커뮤니티에서 사용자 정보 조회를 완료했습니다");
 
     private final String message;
 }


### PR DESCRIPTION
## 🔥 Summary
커뮤니티 유저 정보 API 추가

## ✏️ Describe your changes
[노션](https://www.notion.so/a-whale-of/POST-api-users-communities-info-1b13a12d885142dbbe78f6d1d16661c5) 참고
1.QueryDsl을 이용해서 userId가 userIdList에 속해있으면 원하는 정보만을 select 해서 반환
https://github.com/Hey-Porori/Server_User/blob/e47abc2f87764d455f667fcbedf732ccd10aaf53/src/main/java/porori/backend/user/domain/user/domain/repository/UserRepositoryCustomImpl.java#L32-L43
2. UserQueryService (Domain 서비스) 에서 이 Repository를 호출
https://github.com/Hey-Porori/Server_User/blob/e47abc2f87764d455f667fcbedf732ccd10aaf53/src/main/java/porori/backend/user/domain/user/domain/service/UserQueryService.java#L12-L20
3. UserInfoService에서 위에서 호출한 UserQueryService를 호출
https://github.com/Hey-Porori/Server_User/blob/e47abc2f87764d455f667fcbedf732ccd10aaf53/src/main/java/porori/backend/user/domain/user/application/service/UserInfoService.java#L30-L32

## 🔗 Issue number and link